### PR TITLE
FIX: prevent ValueError on single quote

### DIFF
--- a/src/shellingham/posix/ps.py
+++ b/src/shellingham/posix/ps.py
@@ -28,9 +28,9 @@ def get_process_mapping():
     for line in output.split('\n'):
         try:
             pid, ppid, args = line.strip().split(None, 2)
+            processes[pid] = Process(
+                args=tuple(shlex.split(args)), pid=pid, ppid=ppid,
+            )
         except ValueError:
             continue
-        processes[pid] = Process(
-            args=tuple(shlex.split(args)), pid=pid, ppid=ppid,
-        )
     return processes


### PR DESCRIPTION
Fixes #12.

As you were already checking if `line.strip().split()` fails with a `ValueError`, the easiest was to move the critical `shlex.split()` part into the `try`-block, too.