### PR TITLE
Detect ash, the default shell for Alpine Linux. Close #19

### DIFF
--- a/src/shellingham/_core.py
+++ b/src/shellingham/_core.py
@@ -1,5 +1,5 @@
 SHELL_NAMES = {
-    'sh', 'bash', 'dash',           # Bourne.
+    'sh', 'bash', 'dash', 'ash'     # Bourne.
     'csh', 'tcsh',                  # C.
     'ksh', 'zsh', 'fish',           # Common alternatives.
     'cmd', 'powershell', 'pwsh',    # Microsoft.


### PR DESCRIPTION
see #19 