### PR TITLE
Fix error calling ps on AIX platforms

### DIFF
--- a/src/shellingham/posix/ps.py
+++ b/src/shellingham/posix/ps.py
@@ -12,10 +12,16 @@ class PsNotAvailable(EnvironmentError):
 def get_process_mapping():
     """Try to look up the process tree via the output of `ps`.
     """
+    args = [
+        'ps', '-ww', '-o', 'pid=', '-o', 'ppid=', '-o', 'args=',
+    ]
+    if sys.platform.startswith('aix') or sys.platform.startswith('os400'):
+        # AIX ps does not support the '-w' option. While it does
+        # support the 'w' option in Berkeley mode, this mode does not
+        # support the '-o' option :(
+        args.remove('-ww')
     try:
-        output = subprocess.check_output([
-            'ps', '-ww', '-o', 'pid=', '-o', 'ppid=', '-o', 'args=',
-        ])
+        output = subprocess.check_output(args)
     except OSError as e:    # Python 2-compatible FileNotFoundError.
         if e.errno != errno.ENOENT:
             raise


### PR DESCRIPTION
AIX ps does not support -w option in POSIX mode, only in Berkeley mode ('w'), but Berkeley mode doesn't support -o, so just remove the -ww option and hope for the best.

Fixes #21