### PR TITLE
Switch to parse 'ps wwl' for better compatibility

### DIFF
--- a/src/shellingham/posix/ps.py
+++ b/src/shellingham/posix/ps.py
@@ -1,4 +1,5 @@
 import errno
+import inspect
 import subprocess
 import sys
 
@@ -9,37 +10,88 @@ class PsNotAvailable(EnvironmentError):
     pass
 
 
-def get_process_mapping():
-    """Try to look up the process tree via the output of `ps`.
-    """
+try:
+    getargspec = inspect.getfullargspec
+except AttributeError:  # Old.
+    getargspec = inspect.getargspec
+
+if len(getargspec(subprocess.CalledProcessError.__init__).args) >= 4:
+    CalledProcessError = subprocess.CalledProcessError
+else:   # Old Python versions don't support the stderr argument.
+    def CalledProcessError(returncode, cmd, output, stderr):
+        error = subprocess.CalledProcessError(returncode, cmd, output)
+        error.stderr = stderr
+        return error
+
+
+def _get_ps_output():
+    cmd = ['ps', 'wwl']
     try:
-        output = subprocess.check_output([
-            'ps', '-ww', '-o', 'pid=', '-o', 'ppid=', '-o', 'args=',
-        ])
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
     except OSError as e:    # Python 2-compatible FileNotFoundError.
         if e.errno != errno.ENOENT:
             raise
         raise PsNotAvailable('ps not found')
-    except subprocess.CalledProcessError as e:
-        # `ps` can return 1 if the process list is completely empty.
-        # (sarugaku/shellingham#15)
-        if not e.output.strip():
-            return {}
-        raise
-    if not isinstance(output, str):
+
+    out, err = proc.communicate()
+
+    if isinstance(out, str):
+        result = out
+    else:
         encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
-        output = output.decode(encoding)
-    processes = {}
-    for line in output.split('\n'):
-        try:
-            pid, ppid, args = line.strip().split(None, 2)
-            # XXX: This is not right, but we are really out of options.
-            # ps does not offer a sane way to decode the argument display,
-            # and this is "Good Enough" for obtaining shell names. Hopefully
-            # people don't name their shell with a space, or have something
-            # like "/usr/bin/xonsh is uber". (sarugaku/shellingham#14)
-            args = tuple(a.strip() for a in args.split(' '))
-        except ValueError:
+        result = out.decode(encoding)
+
+    if proc.returncode == 1:
+        # `ps` can return 1 if the process list is completely empty.
+        # In this case the output would only contain the header row.
+        # (sarugaku/shellingham#15, sarugaku/shellingham#22)
+        if err.strip() or len(result.split('\n', 1)) != 1:
+            raise CalledProcessError(proc.returncode, cmd, out, err)
+    elif proc.returncode:
+        raise CalledProcessError(proc.returncode, cmd, out, err)
+
+    return result
+
+
+def _parse_ps_header(header):
+    start = 0
+    colchs = []
+    for i, c in enumerate(header):
+        if c != ' ':
+            colchs.append(c)
             continue
-        processes[pid] = Process(args=args, pid=pid, ppid=ppid)
-    return processes
+        if colchs:
+            yield (''.join(colchs), slice(start, i))
+            start = i
+        colchs = []
+    yield (''.join(colchs), slice(start, None))
+
+
+def _parse_ps_output(output):
+    lines_iter = iter(output.split('\n'))
+    try:
+        header = next(lines_iter)
+    except StopIteration:
+        return
+    columns = {k.lower(): v for k, v in _parse_ps_header(header)}
+    for line in lines_iter:
+        pid, ppid, args = (
+            line[columns[k]].strip()
+            for k in ('pid', 'ppid', 'command')
+        )
+        # XXX: This is not right, but we are really out of options.
+        # ps does not offer a sane way to decode the argument display,
+        # and this is "Good Enough" for obtaining shell names. Hopefully
+        # people don't name their shell with a space, or have something
+        # like "/usr/bin/xonsh is uber". (sarugaku/shellingham#14)
+        args = tuple(a.strip() for a in args.split(' '))
+        yield pid, Process(args=args, pid=pid, ppid=ppid)
+
+
+def get_process_mapping():
+    """Try to look up the process tree via the output of `ps`.
+    """
+    output = _get_ps_output()
+    return dict(_parse_ps_output(output))

--- a/tests/test_ps.py
+++ b/tests/test_ps.py
@@ -1,0 +1,38 @@
+from shellingham.posix._core import Process
+from shellingham.posix.ps import _parse_ps_header, _parse_ps_output
+
+
+def test_parse_ps_header():
+    header = '   UID   PID  PPID CPU PRI NI      VSZ    TIME COMMAND'
+    parsed = dict(_parse_ps_header(header))
+    assert parsed == {
+        'UID': slice(0, 6),
+        'PID': slice(6, 12),
+        'PPID': slice(12, 18),
+        'CPU': slice(18, 22),
+        'PRI': slice(22, 26),
+        'NI': slice(26, 29),
+        'VSZ': slice(29, 38),
+        'TIME': slice(38, 46),
+        'COMMAND': slice(46, None),
+    }
+
+
+PS_OUTPUT = (
+"""\
+  UID   PID  PPID CPU PRI NI      VSZ    RSS WCHAN  STAT   TT       TIME COMMAND
+  501 90585 90584   0  31  0  4296844   2896 -      S    s000    0:00.19 -bash
+  501 96095 90585   0  31  0  4258724    180 -      S+   s000    0:00.01 pbcopy
+  501 82490 82489   0  31  0  4296844    496 -      S+   s001    0:00.11 -bash
+  501 82557 82556   0  31  0  4296844   1260 -      S+   s002    0:00.43 -bash
+""")    # noqa
+
+
+def test_parse_ps_output():
+    parsed = dict(_parse_ps_output(iter(PS_OUTPUT.split('\n'))))
+    assert parsed == {
+        '90585': Process(pid='90585', ppid='90584', args='-bash'),
+        '96095': Process(pid='96095', ppid='90585', args='pbcopy'),
+        '82490': Process(pid='82490', ppid='82489', args='-bash'),
+        '82557': Process(pid='82557', ppid='82556', args='-bash'),
+    }


### PR DESCRIPTION
The “Berkeley standard’ argument has better compatibility than either BSD or GNU standard.

Fix #21, close #22.

@kadler and @sirn It’d be wonderful if you could test this on your environments to make sure things still work.