### PR TITLE
strip python subprocess prefix to enable python shell detections

### DIFF
--- a/src/shellingham/posix/__init__.py
+++ b/src/shellingham/posix/__init__.py
@@ -54,7 +54,7 @@ def get_shell(pid=None, max_depth=6):
     mapping = _get_process_mapping()
     for k, v in mapping.items():  # handle xonsh shell by stripping "python" prefixes
         paths = [os.path.basename(arg).lower() for arg in v.args]
-        if 'python' in paths and 'xonsh' in paths:
+        if any(python in paths for python in ['python', 'python2', 'python3']) and 'xonsh' in paths:
             mapping[k] = v._replace(args=[arg for arg in v.args[1:] if not arg.startswith('-')])
     for proc_cmd in _iter_process_command(mapping, pid, max_depth):
         if proc_cmd.startswith('-'):    # Login shell! Let's use this.

--- a/src/shellingham/posix/__init__.py
+++ b/src/shellingham/posix/__init__.py
@@ -52,8 +52,9 @@ def get_shell(pid=None, max_depth=6):
     """
     pid = str(pid or os.getpid())
     mapping = _get_process_mapping()
-    for k, v in mapping.items():  # flatten python processes by removing python prefix
-        if 'python' in v.args[0]:
+    for k, v in mapping.items():  # handle xonsh shell by stripping "python" prefixes
+        paths = [os.path.basename(arg).lower() for arg in v.args]
+        if 'python' in paths and 'xonsh' in paths:
             mapping[k] = v._replace(args=[arg for arg in v.args[1:] if not arg.startswith('-')])
     for proc_cmd in _iter_process_command(mapping, pid, max_depth):
         if proc_cmd.startswith('-'):    # Login shell! Let's use this.

--- a/src/shellingham/posix/__init__.py
+++ b/src/shellingham/posix/__init__.py
@@ -52,6 +52,9 @@ def get_shell(pid=None, max_depth=6):
     """
     pid = str(pid or os.getpid())
     mapping = _get_process_mapping()
+    for k, v in mapping.items():  # flatten python processes by removing python prefix
+        if 'python' in v.args[0]:
+            mapping[k] = v._replace(args=[arg for arg in v.args[1:] if not arg.startswith('-')])
     for proc_cmd in _iter_process_command(mapping, pid, max_depth):
         if proc_cmd.startswith('-'):    # Login shell! Let's use this.
             return _get_login_shell(proc_cmd)


### PR DESCRIPTION
This fixes https://github.com/sarugaku/shellingham/issues/26

```
$ ps -ww -o "pid=" -o "ppid=" -o "args="                                                                              
  17309    1624 /usr/bin/python -u /usr/bin/xonsh
  30755   17309 /usr/bin/ps -ww -o pid= -o ppid= -o args=
$ python -c "import shellingham;print(shellingham.detect_shell())"                                                    
('xonsh', '/usr/bin/xonsh')
```