### PR TITLE
Add simple Github Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+
+name: ci
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: cd src; python -c 'import shellingham; print(shellingham.detect_shell())'
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: cd src; python -c 'import shellingham; print(shellingham.detect_shell())'


### PR DESCRIPTION
As described in https://github.com/sarugaku/shellingham/issues/35, this is failing on macOS but passing on Linux.

CI on more than one OS is probably a good thing to have anyway, once it's passing.