### PR TITLE
Modern python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10.0-alpha.7]
+        python-version: [3.7, 3.8, 3.9, 3.10.0-alpha.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,32 @@
-on: [push, pull_request]
-
 name: ci
 
-jobs:
-  linux:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: cd src; python -c 'import shellingham; print(shellingham.detect_shell())'
+on:
+  - push
+  - pull_request
 
-  macos:
-    runs-on: macos-latest
+jobs:
+  build:
+    runs-on: ${{ matrix.platform }}
     continue-on-error: true
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10.0-alpha.7]
+
     steps:
-    - uses: actions/checkout@v2
-    - run: cd src; python -c 'import shellingham; print(shellingham.detect_shell())'
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv tox tox-gh-actions
+
+      - name: Test with tox
+        run: tox
+        env:
+          PLATFORM: ${{ matrix.platform }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
-.pytest_cache
 .venv
 __pycache__
 
@@ -9,3 +8,10 @@ dist
 *.egg-info
 
 *.py[co]
+
+# Editors
+.vscode
+
+# Testing
+.tox
+.pytest_cache

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,8 @@ pytest = '*'
 pytest-mock = '*'
 setl = '*'
 towncrier = '*'
+tox = '*'
+tox-gh-actions = '*'
 
 [scripts]
 release = 'inv release'

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,14 +1,14 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "47bb9b2e4bc994a062b02cec97541a7cadf81123a0a6dc8c8eb9083c81358cbc"
+            "sha256": "c277123eeb5f15d86bce9ca7c9db234b360740bb42470d0a808fb80563744cab"
         },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [
             {
                 "name": "pypi",
-                "url": "https://pypi.org/simple",
+                "url": "https://pypi.python.org/simple",
                 "verify_ssl": true
             }
         ]
@@ -20,6 +20,13 @@
         }
     },
     "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
+        },
         "arpeggio": {
             "hashes": [
                 "sha256:920d12cc762edb2eb56daae64a14c93e43dc181b481c88fc79314c0df6ee639e",
@@ -111,6 +118,12 @@
             ],
             "version": "==7.1.2"
         },
+        "click-default-group": {
+            "hashes": [
+                "sha256:d9560e8e8dfa44b3562fbc9425042a0fd6d21956fcc2db0077f63f34253ab904"
+            ],
+            "version": "==1.2.2"
+        },
         "colorama": {
             "hashes": [
                 "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
@@ -135,12 +148,26 @@
             ],
             "version": "==3.4.7"
         },
+        "distlib": {
+            "hashes": [
+                "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb",
+                "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"
+            ],
+            "version": "==0.3.1"
+        },
         "docutils": {
             "hashes": [
                 "sha256:a71042bb7207c03d5647f280427f14bfbd1a65c9eb84f4b341d85fafb6bb4bdf",
                 "sha256:e2ffeea817964356ba4470efba7c2f42b6b0de0b04e66378507e3e2504bbff4c"
             ],
             "version": "==0.17"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
+                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
+            ],
+            "version": "==3.0.12"
         },
         "idna": {
             "hashes": [
@@ -163,21 +190,27 @@
             ],
             "version": "==21.3.0"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
         "invoke": {
             "hashes": [
-                "sha256:87b3ef9d72a1667e104f89b159eaf8a514dbf2f3576885b2bbdefe74c3fb2132",
-                "sha256:93e12876d88130c8e0d7fd6618dd5387d6b36da55ad541481dfa5e001656f134",
-                "sha256:de3f23bfe669e3db1085789fd859eb8ca8e0c5d9c20811e2407fa042e8a5e15d"
+                "sha256:7e44d98a7dc00c91c79bac9e3007276965d2c96884b3c22077a9f04042bd6d90",
+                "sha256:da7c2d0be71be83ffd6337e078ef9643f41240024d6b2659e7b46e0b251e339f",
+                "sha256:f0c560075b5fb29ba14dad44a7185514e94970d1b9d57dcd3723bec5fed92650"
             ],
             "index": "pypi",
-            "version": "==1.4.1"
+            "version": "==1.5.0"
         },
         "jeepney": {
             "hashes": [
                 "sha256:7d59b6622675ca9e993a6bd38de845051d315f8b0c72cca3aef733a20b648657",
                 "sha256:aec56c0eb1691a841795111e184e13cad504f7703b9a64f63020816afa79a8ae"
             ],
-            "markers": "sys_platform == 'linux'",
             "version": "==0.6.0"
         },
         "jinja2": {
@@ -251,13 +284,6 @@
             ],
             "version": "==1.1.1"
         },
-        "more-itertools": {
-            "hashes": [
-                "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced",
-                "sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713"
-            ],
-            "version": "==8.7.0"
-        },
         "packaging": {
             "hashes": [
                 "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
@@ -267,11 +293,11 @@
         },
         "parver": {
             "hashes": [
-                "sha256:1b37a691af145a3a193eff269d53ba5b2ab16dfbb65d47d85360755919f5fe4b",
-                "sha256:72d056b8f8883ac90eef5554a9c8a47fac39d3b66479f3d2c8d5bc21b849cdba"
+                "sha256:41a548c51b006a2f2522b54293cbfd2514bffa10774ece8430c9964a20cbd8b4",
+                "sha256:c902e0653bcce927cc156a7fd9b3a51924cbce3bf3d0bfd49fc282bfd0c5dfd3"
             ],
             "index": "pypi",
-            "version": "==0.2.1"
+            "version": "==0.3.1"
         },
         "pep517": {
             "hashes": [
@@ -324,19 +350,19 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
-                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
+                "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634",
+                "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"
             ],
             "index": "pypi",
-            "version": "==5.3.5"
+            "version": "==6.2.3"
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:b35eb281e93aafed138db25c8772b95d3756108b601947f89af503f8c629413f",
-                "sha256:cb67402d87d5f53c579263d37971a164743dc33c159dfb4fb4a86f37c5552307"
+                "sha256:379b391cfad22422ea2e252bdfc008edd08509029bcde3c25b2c0bd741e0424e",
+                "sha256:a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==3.5.1"
         },
         "readme-renderer": {
             "hashes": [
@@ -376,11 +402,11 @@
         },
         "setl": {
             "hashes": [
-                "sha256:45c7ef74b5df6e143801cbe716344b504cde3da6a0f51cfe30e799e9d16047c4",
-                "sha256:a305a77ecedb5affc1f49bbb4f0a3d3a382399f2227444920caf809af89848d7"
+                "sha256:92df77f807e1fb0ab390f60cba5d549dcfadf2fd8463a90b16d896ac6fc169e8",
+                "sha256:f283b2745c35c2466426c4bfb7bd4669ea257182df5716fa353bcc33e198062e"
             ],
             "index": "pypi",
-            "version": "==0.8.5"
+            "version": "==0.10.0"
         },
         "six": {
             "hashes": [
@@ -398,11 +424,27 @@
         },
         "towncrier": {
             "hashes": [
-                "sha256:48251a1ae66d2cf7e6fa5552016386831b3e12bb3b2d08eb70374508c17a8196",
-                "sha256:de19da8b8cb44f18ea7ed3a3823087d2af8fcf497151bb9fd1e1b092ff56ed8d"
+                "sha256:6eed0bc924d72c98c000cb8a64de3bd566e5cb0d11032b73fcccf8a8f956ddfe",
+                "sha256:e6ccec65418bbcb8de5c908003e130e37fe0e9d6396cb77c1338241071edc082"
             ],
             "index": "pypi",
-            "version": "==19.2.0"
+            "version": "==21.3.0"
+        },
+        "tox": {
+            "hashes": [
+                "sha256:05a4dbd5e4d3d8269b72b55600f0b0303e2eb47ad5c6fe76d3576f4c58d93661",
+                "sha256:e007673f3595cede9b17a7c4962389e4305d4a3682a6c5a4159a1453b4f326aa"
+            ],
+            "index": "pypi",
+            "version": "==3.23.0"
+        },
+        "tox-gh-actions": {
+            "hashes": [
+                "sha256:7b0064263d94bbb12d3e217e17d14ee9cff37c1d50ae88bc5968793d90546a68",
+                "sha256:b6b50ba3e78e572045bff04d53e1eda59d26fa33e05ea008da5105ec54b5be8c"
+            ],
+            "index": "pypi",
+            "version": "==2.5.0"
         },
         "tqdm": {
             "hashes": [
@@ -423,15 +465,14 @@
                 "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
                 "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
-            "index": "pypi",
             "version": "==1.26.4"
         },
-        "wcwidth": {
+        "virtualenv": {
             "hashes": [
-                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
-                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
+                "sha256:49ec4eb4c224c6f7dd81bb6d0a28a09ecae5894f4e593c89b0db0885f565a107",
+                "sha256:83f95875d382c7abafe06bd2a4cdd1b363e1bb77e02f155ebe8ac082a916b37c"
             ],
-            "version": "==0.2.5"
+            "version": "==20.4.3"
         },
         "webencodings": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,10 @@ classifier =
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,13 +16,7 @@ classifier =
     Intended Audience :: Developers
     License :: OSI Approved :: ISC License (ISCL)
     Operating System :: OS Independent
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.6
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -33,7 +27,7 @@ classifier =
 package_dir =
     = src
 packages = find:
-python_requires = >=2.6,!=3.0,!=3.1,!=3.2,!=3.3
+python_requires = >=3.4
 install_requires =
 zip_safe = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = py26, py27, py34, py35, py36, py37, py38, py39, py310
+
+[gh-actions]
+python =
+    2.6: py26
+    2.7: py27
+    3.4: py34
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
+[testenv]
+allowlist_externals = pipenv
+commands =
+    pipenv install --dev
+
+[testenv:test]
+deps =
+    pytest
+
+commands =
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,8 @@
 [tox]
-envlist = py26, py27, py34, py35, py36, py37, py38, py39, py310
+envlist = py37, py38, py39, py310
 
 [gh-actions]
 python =
-    2.6: py26
-    2.7: py27
-    3.4: py34
-    3.5: py35
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
This drops support for old Python versions.

Note that support is also dropped for Python 3.6, which strictly hasn't reached end-of-life yet, but is unsupported by the `setl` dependency. Since `setl` is only a dev dependency, 3.6 support could still be maintained, but I will leave that for @uranusjr to decide. I personally don't want to commit any time to getting 3.6 support set up, particularly since these changes contain no code changes but merely 'project health and maintainer sanity' changes, and pinning to 1.4 would be a more appropriate solution for downstream projects needing 3.6 support.

This limits the test matrix to 12 instances. Note also that MacOS now magically doesn't fail (no idea why). Windows CI has also been added.

This depends on the two prior pull requests.

--

Edit: Fix #47, close #48, close #49 (for convinience -- @uranusjr)