### PR TITLE
Add "nu" to _core.py to support detect NuShell

### DIFF
--- a/src/shellingham/_core.py
+++ b/src/shellingham/_core.py
@@ -3,7 +3,7 @@ SHELL_NAMES = (
     | {"csh", "tcsh"}  # C.
     | {"ksh", "zsh", "fish"}  # Common alternatives.
     | {"cmd", "powershell", "pwsh"}  # Microsoft.
-    | {"elvish", "xonsh"}  # More exotic.
+    | {"elvish", "xonsh", "nu"}  # More exotic.
 )
 
 


### PR DESCRIPTION
Hello Thank you for your project,
I am `poetry` user. Poetry use `shellingham` to detect shell for activating virtual environment. [NuShell](https://www.nushell.sh/) cannot the detected by poetry in Windows 10 show this PR fix that.

after the change `shellingham` can detect `nushell`:
```
D:\GitHub\demo-shellingham\demo_shellingham〉bat -p .\check.py                                                                                    03/24/2022 11:01:34 AM
import shellingham
print(shellingham.detect_shell())

D:\GitHub\demo-shellingham\demo_shellingham〉python .\check.py                                                                                    03/24/2022 11:01:43 AM
('nu', 'C:\\Program Files\\nu\\bin\\nu.exe')
D:\GitHub\demo-shellingham\demo_shellingham〉                                                                                                     03/24/2022 11:01:51 AM
```
Hope you all have a nice day 👍 