### PR TITLE
Limit package installation to Python >= 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifier =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.4
+python_requires = >=3.7
 install_requires =
 zip_safe = true
 


### PR DESCRIPTION
`python_requires = >=3.4` should be updated as `python_requires = >=3.7`, else Pypi will still list it as available for Python < 3.7.

Fixes #61

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>