### PR TITLE
Correct detect proc by raising exception eagerly

### DIFF
--- a/news/78.bugfix.rst
+++ b/news/78.bugfix.rst
@@ -1,0 +1,1 @@
+Detect proc format eagerly so it throws the error at the correct location.


### PR DESCRIPTION
Fixes https://github.com/sarugaku/shellingham/issues/78

The problem was from changing the `impl.iter_process_parents` to a generator rather than a plan old iterator. The body of generators isn't evaluated until the first time their `next` method is called, so the check here:

https://github.com/sarugaku/shellingham/blob/bf9f580f7b3f0ff2254730462ed7b50898dd1aa8/src/shellingham/posix/__init__.py#L46-L47 

is incorrect because the environment error is raised here instead:

https://github.com/sarugaku/shellingham/blob/bf9f580f7b3f0ff2254730462ed7b50898dd1aa8/src/shellingham/posix/__init__.py#L108

or, when the generator is unpacked. 

The fix is to just wrap the inner generator - so the `detect_proc` function is called in the expected place, and if it passes then the called generator is returned and equivalant to the current generator


