### PR TITLE
Add trusted_publishing via Pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: pypi
+      name: publish
       url: https://pypi.org/p/shellingham
     needs:
     - build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,11 @@ jobs:
   publish:
     name: Publish release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/shellingham
     needs:
     - build
 
@@ -42,8 +47,6 @@ jobs:
         path: dist
 
     - name: Push build artifacts to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.5.0
+      uses: pypa/gh-action-pypi-publish@v1.8.14
       with:
-        skip_existing: true
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        skip-existing: true


### PR DESCRIPTION
Benefit: If someone submits a PR, they cannot steal the `PYPI_TOKEN`
Closes #84 

Adapted from:
https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing

There are some steps that the admin of this repo need to do. Both are UI actions.
## TODO:
1.  Pypi.org Follow pypi guide https://docs.pypi.org/trusted-publishers/adding-a-publisher/

This should roughly do it
```
- owner "sarugaku"
- repository name "shellingham"
- workflow "publish.yml"
- environment name "pypi" # The name of environment in the yaml needs to match the name of the github UI and what you put on pypi
```

2. Github.com Create a environment named "pypi" in github UI under environments.
Below a screenshot of project github.com/michaelfeil/infinity and added e.g. me as Required Reviewer (e.g. if someone else pushes a tag to my repo, this stalls the github CI, and I get a notification to approve the publish.yml workflow)
![image](https://github.com/sarugaku/shellingham/assets/63565275/5f1155f5-ba81-462a-a54b-6160daf87a7b)
