### PR TITLE
Add check for aarch64 on QEmu

### DIFF
--- a/src/shellingham/posix/__init__.py
+++ b/src/shellingham/posix/__init__.py
@@ -7,7 +7,8 @@ from . import proc, ps
 # Based on QEMU docs: https://www.qemu.org/docs/master/user/main.html
 QEMU_BIN_REGEX = re.compile(
     r"""qemu-
-        (alpha
+        (aarch64
+        |alpha
         |armeb
         |arm
         |m68k


### PR DESCRIPTION
I discovered that `shellingham` did not detect the correct shell when running in Docker on a x64 machine while emulating `linux/arm64`.

Through some debugging, and inspecting the running code, I saw the `name` variable in `shellingham/posix/__init__.py:92` was `qemu-aarch64`.
Adding that to the regex solved the problem.

I hope you find this useful, and thanks for a good package 😊 