### PR TITLE
Add support for (prefix) shell

### DIFF
--- a/src/shellingham/_core.py
+++ b/src/shellingham/_core.py
@@ -3,7 +3,7 @@ SHELL_NAMES = (
     | {"csh", "tcsh"}  # C.
     | {"ksh", "zsh", "fish"}  # Common alternatives.
     | {"cmd", "powershell", "pwsh"}  # Microsoft.
-    | {"elvish", "xonsh", "nu"}  # More exotic.
+    | {"elvish", "xonsh", "nu", "shell"}  # More exotic.
 )
 
 


### PR DESCRIPTION
Shell url: https://github.com/prefix-dev/shell/

I tested on macOS and Windows.

Before this PR on Windows:

    $ python -c "import shellingham; print(shellingham.detect_shell())"
    ('cmd', 'C:\\Windows\\System32\\cmd.exe')

With this PR on Windows:

    $ python -c "import shellingham; print(shellingham.detect_shell())"
    ('shell', 'C:\\Users\\ondrejcertik\\bin\\shell.exe')